### PR TITLE
additionally supporting JSONRPC

### DIFF
--- a/INWX/Domrobot.php
+++ b/INWX/Domrobot.php
@@ -96,8 +96,16 @@ class Domrobot
 		if (!empty($this->clTRID)) {
 			$params['clTRID'] = $this->clTRID;
 		}
+
+		$useJSON = preg_match('!/jsonrpc!',$this->address);
+
+		if ($useJSON) {
+			$request = json_encode(array('method' => $object.".".$method, 'params' => $params));
+		}
+		else {
+			$request = xmlrpc_encode_request(strtolower($object.".".$method), $params, array("encoding"=>"UTF-8","escaping"=>"markup","verbosity"=>"no_white_space"));
+		}
 		
-		$request = xmlrpc_encode_request(strtolower($object.".".$method), $params, array("encoding"=>"UTF-8","escaping"=>"markup","verbosity"=>"no_white_space"));
 	
 		$header[] = "Content-Type: text/xml";   
 		$header[] = "Connection: keep-alive";
@@ -122,7 +130,12 @@ class Domrobot
 			echo "Response:\n".$response."\n";
 		}
 
-		return xmlrpc_decode($response,'UTF-8');
+		if ($useJSON) {
+			return json_decode($response);
+		}
+		else {
+			return xmlrpc_decode($response,'UTF-8');
+		}
 	}
 	
 	private function _getSecretCode($secret) {

--- a/example.php
+++ b/example.php
@@ -15,6 +15,16 @@ require "INWX/Domrobot.php";
 //$addr = "https://api.domrobot.com/xmlrpc/";
 //$addr = "https://api.ote.domrobot.com/xmlrpc/";
 
+// Alternatively, you may use JSON (experimental):
+//
+//$addr = "https://api.domrobot.com/jsonrpc/";
+//$addr = "https://api.ote.domrobot.com/jsonrpc/";
+
+// Remeber when using JSON you get objects back, not arrays, so use:
+//   $res->code
+// instead of:
+//   $res['code']
+
 $usr = "your_username";
 $pwd = "your_password";
 


### PR DESCRIPTION
INWX API is now able to talk JSON. So the domrobot class should use JSON encoding whenever /jsonrpc/ is requested instead of /xmlrpc/. 

This is still a liitle bit experimental regarding encoding issues.
