### PR TITLE
Compatibility with psr/log 3.0 LoggerAwareInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "ext-curl": "*",
         "monolog/monolog": ">= 2.0.0"
     },

--- a/src/Domrobot.php
+++ b/src/Domrobot.php
@@ -385,7 +385,7 @@ class Domrobot implements LoggerAwareInterface
     /**
      * @inheritDoc
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
In a Laravel 9 project running on PHP 8.0 / 8.1, I struggled with this:

```
Declaration of INWX\Domrobot::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void
```

Had to fix setLogger() return type to match new `LoggerAwareInterface` from [psr/log](https://github.com/php-fig/log) 3.0.0. Please also drop PHP 7 support, can't harm.