### PR TITLE
Call error handling

### DIFF
--- a/src/ExceptionCallFailed.php
+++ b/src/ExceptionCallFailed.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace INWX;
+
+class ExceptionCallFailed extends \Exception {
+
+}


### PR DESCRIPTION
Hi,

PHP's `json_decode` and PHP's `xmlrpc_decode` will return null when the parsing failed, but Domrobot::Call has declared to return an array. An uncatchable type error will be thrown:
TypeError: INWX\Domrobot::call(): Return value must be of type array, null returned

There are two variants to implement an error handling:
1. Domrobot::call could return array|null
2. Domrobot::call could raise an catchable exception

I would prefer to raise an exception in this case because:
- Domrobot::login and Domrobot::logout will not need any own error handling
- The new exception is extending \Exception, so IDEs (like PHPStorm) will show a warning, when the error handling is missing