### PR TITLE
Upgraded to monolog/monolog 3 to support Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": "^8.1",
         "ext-curl": "*",
-        "monolog/monolog": "^2.0"
+        "monolog/monolog": "^3.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Please drop PHP 8.0 support and upgrade Monolog to 3.x, so that this package can be used in a Laravel 10 project without any dependency issues.